### PR TITLE
Support AWS WAF for ALB

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AWS WAF custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-waf -web-acl-id=<aws-waf-web-acl-id> [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-waf -web-acl-id=<aws-waf-web-acl-id> [-access-key-id=<id>] [-secret-access-key=<key>] [-region=<region>] [-tempfile=<tempfile>]
 ```
 
 ## AWS IAM Policy
@@ -22,7 +22,3 @@ the credential provided manually or fetched automatically by IAM Role should hav
 [plugin.metrics.aws-waf]
 command = "/path/to/mackerel-plugin-aws-waf -web-acl-id=your-web-acl-id"
 ```
-
-## Notes
-
-This plugin only supports AWS WAF for CloudFront, and not the metrics of WAF for ALB.


### PR DESCRIPTION
We tried to get AWS WAF metrics but got an error `WAFNonexistentItemException: The referenced item does not exist.` It seems that the plugin needs to specify aws region to get the metrics of AWS WAF for ALB.

* Before patching
```
$ mackerel-plugin-aws-waf -web-acl-id="xxx" -access-key-id=xxx -secret-access-key=xxx
2018/10/31 17:15:43 WAFNonexistentItemException: The referenced item does not exist.
        status code: 400, request id: xxx
```

* After patching
```
$ mackerel-plugin-aws-waf -web-acl-id="xxx" -access-key-id=xxx -secret-access-key=xxx -region=ap-northeast-1
2018/10/31 17:16:13 ALL.BlockedRequests: fetched no datapoints
2018/10/31 17:16:13 Default_Action.BlockedRequests: fetched no datapoints
2018/10/31 17:16:13 Default_Action.CountedRequests: fetched no datapoints
2018/10/31 17:16:13 hiroakistestingrule.AllowedRequests: fetched no datapoints
2018/10/31 17:16:13 hiroakistestingrule.BlockedRequests: fetched no datapoints
waf.Requests.ALL.AllowedRequests        42      1540973773
waf.Requests.Default_Action.AllowedRequests     42      1540973773
waf.Requests.ALL.CountedRequests        9       1540973773
waf.Requests.hiroakistestingrule.CountedRequests        9       1540973773
```